### PR TITLE
added TAP support in output

### DIFF
--- a/smtpscript/parse.y
+++ b/smtpscript/parse.y
@@ -313,7 +313,7 @@ procparams	: procparam procparams
 		;
 
 proc		: PROC STRING {
-			printf("proc %s\n", $2);
+			printf("# proc %s\n", $2);
 			currproc = procedure_create(currscript, $2);
 			if (currproc == NULL)
 				file->errors++;

--- a/smtpscript/smtpscript.c
+++ b/smtpscript/smtpscript.c
@@ -499,7 +499,7 @@ run_testcase(struct procedure *proc)
 			print_testcase("ok", proc->name, c.reason, "SKIP", test_total);
 		}
 		else {
-			print_testcase("ok", proc->name, c.reason, "", test_total);
+			print_testcase("ok", proc->name, c.reason, NULL, test_total);
 			test_pass += 1;
 		}
 
@@ -521,7 +521,7 @@ run_testcase(struct procedure *proc)
                         print_testcase("ok", proc->name, c.reason, "SKIP", test_total);
                 }
 		else {
-			print_testcase("not ok", proc->name, c.reason, "", test_total);
+			print_testcase("not ok", proc->name, c.reason, NULL, test_total);
 			test_fail += 1;
 		}
 
@@ -530,7 +530,7 @@ run_testcase(struct procedure *proc)
 	case RES_ERROR:
 		test_error += 1;
 		test_total += 1;
-		print_testcase("not ok", proc->name, c.reason, "", test_total);
+		print_testcase("not ok", proc->name, c.reason, NULL, test_total);
 		break;
 	}
 
@@ -543,7 +543,7 @@ run_testcase(struct procedure *proc)
 void print_testcase(char *status, char *name, char *reason, char *directive, size_t number)
 {
 	printf("%s %zu", status, number);
-	if (directive != "")
+	if (directive)
 		printf(" - %s # %s\n", name, directive);
 	else
 		if (reason)


### PR DESCRIPTION
TAP is a Test Anything Protocol. It is a format used for test output. See 
It would be nice to implement TAP for smtpscript. It allows to push test results to test portals like Tapper (tapper-testing.org).

Now output looks like:

$ smtpscript/smtpscript -t regression-mailfrom  
# proc init-helo
# smtpscript is an SMTP testing framework

TAP version 13
ok 1 - mailfrom-empty
ok 2 - mailfrom-without-local
ok 3 - mailfrom-without-domain
ok 4 - mailfrom-max-local-part1
ok 5 - mailfrom-max-local-part2
not ok 6 - mailfrom-max-domain1 # unexpected response code2: 553 Sender address syntax error
not ok 7 - mailfrom-max-domain2 # unexpected response code2: 553 Sender address syntax error
ok 8 - mailfrom-max-email
ok 9 - mailrom-min-email
not ok 10 - mailfrom-special-symbols1 # unexpected response code2: 553 Sender address syntax error
ok 11 - mailfrom-special-symbols2

and from my point of view it is more readable than earlier :)
